### PR TITLE
chore: Dockerfile を整理し requirements インストール処理を統合

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,17 +6,22 @@ ENV PYTHONUNBUFFERED=1
 
 # Install system packages and Claude Code in a single layer
 RUN apt-get update && apt-get install -y \
+    git \
     curl \
-    fonts-ipaexfont \
-    libopencv-dev \
-    sqlite3 \
     lhasa \
     wget \
-    locales \
+    bash-completion \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://claude.ai/install.sh | bash
+    # Install Claude Code
+    && curl -fsSL https://claude.ai/install.sh | bash 
+
+WORKDIR /workspaces
+COPY requirements.txt /workspaces
+RUN python -m pip install --upgrade pip && python -m pip install -r requirements.txt
+RUN echo 'autoload bashcompinit && bashcompinit' >> ~/.bashrc && echo 'source /usr/share/bash-completion/completions/git' >> ~/.bashrc
 
     
 ENV PATH="/root/.local/bin:$PATH"
 
-WORKDIR /workspaces
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,6 @@
         "ms-azuretools.vscode-docker"  // Docker extension
       ]
     }
-  },
-  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -r requirements.txt"
+  }
+  //"postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -r requirements.txt"
 }


### PR DESCRIPTION
- 不要なシステムパッケージ（fonts-ipaexfont、libopencv-dev、sqlite3、locales）を削除
- git と bash-completion を追加
- pip による requirements.txt インストール処理を Dockerfile 内に移動
- git の bash 補完を自動で有効化するよう設定
- devcontainer.json の postCreateCommand を削除してコンテナ起動時間を短縮